### PR TITLE
Fix big endian

### DIFF
--- a/src/d2s.rs
+++ b/src/d2s.rs
@@ -534,7 +534,7 @@ unsafe fn to_chars(v: FloatingDecimal64, sign: bool, result: *mut u8) -> usize {
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub unsafe fn d2s_buffered_n(f: f64, result: *mut u8) -> usize {
     // Step 1: Decode the floating-point number, and unify normalized and subnormal cases.
-    let bits = mem::transmute::<f64, u64>(f).to_le();
+    let bits = mem::transmute::<f64, u64>(f);
 
     // Decode bits into sign, mantissa, and exponent.
     let ieee_sign = ((bits >> (DOUBLE_MANTISSA_BITS + DOUBLE_EXPONENT_BITS)) & 1) != 0;

--- a/src/f2s.rs
+++ b/src/f2s.rs
@@ -474,7 +474,7 @@ unsafe fn to_chars(v: FloatingDecimal32, sign: bool, result: *mut u8) -> usize {
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub unsafe fn f2s_buffered_n(f: f32, result: *mut u8) -> usize {
     // Step 1: Decode the floating-point number, and unify normalized and subnormal cases.
-    let bits = mem::transmute::<f32, u32>(f).to_le();
+    let bits = mem::transmute::<f32, u32>(f);
 
     // Decode bits into sign, mantissa, and exponent.
     let ieee_sign = ((bits >> (FLOAT_MANTISSA_BITS + FLOAT_EXPONENT_BITS)) & 1) != 0;

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -16,7 +16,7 @@ use no_panic::no_panic;
 #[cfg_attr(must_use_return, must_use)]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub unsafe fn d2s_buffered_n(f: f64, result: *mut u8) -> usize {
-    let bits = mem::transmute::<f64, u64>(f).to_le();
+    let bits = mem::transmute::<f64, u64>(f);
     let sign = ((bits >> (DOUBLE_MANTISSA_BITS + DOUBLE_EXPONENT_BITS)) & 1) != 0;
     let ieee_mantissa = bits & ((1u64 << DOUBLE_MANTISSA_BITS) - 1);
     let ieee_exponent =
@@ -86,7 +86,7 @@ pub unsafe fn d2s_buffered_n(f: f64, result: *mut u8) -> usize {
 #[cfg_attr(must_use_return, must_use)]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub unsafe fn f2s_buffered_n(f: f32, result: *mut u8) -> usize {
-    let bits = mem::transmute::<f32, u32>(f).to_le();
+    let bits = mem::transmute::<f32, u32>(f);
     let sign = ((bits >> (FLOAT_MANTISSA_BITS + FLOAT_EXPONENT_BITS)) & 1) != 0;
     let ieee_mantissa = bits & ((1u32 << FLOAT_MANTISSA_BITS) - 1);
     let ieee_exponent =


### PR DESCRIPTION
We only perform integer arithmetic on these integers, not index their bytes directly, so these `to_le()` result in printing the wrong number on big endian targets. We printed the number as if its bytes were reversed, for example:

    input number: 5.764607523034235E39
    little-endian bits:
    01001000 00110000 11110000 11001111 00000110 01001101 11010101 10010010

    printed as: -6.034215271814797E-218
    little-endian bits:
    10010010 11010101 01001101 00000110 11001111 11110000 00110000 01001000

Fixes #2.