### PR TITLE
Disable i128 integers on Emscripten targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,9 +11,15 @@ fn main() {
         None => return,
     };
 
+    let target = env::var("TARGET").unwrap();
+    let emscripten = target == "asmjs-unknown-emscripten" || target == "wasm32-unknown-emscripten";
+
     // 128-bit integers stabilized in Rust 1.26:
     // https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
-    if minor >= 26 {
+    //
+    // Disabled on Emscripten targets as Emscripten doesn't
+    // currently support integers larger than 64 bits.
+    if minor >= 26 && !emscripten {
         println!("cargo:rustc-cfg=integer128");
     }
 


### PR DESCRIPTION
Emscripten doesn't currently support i128 and will fail with the following error if they're used:

```
LLVM ERROR: Instruction not yet supported for integer types larger than 64 bits
```