### PR TITLE
Add MaybeUninit support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,12 @@ fn main() {
     if minor >= 27 {
         println!("cargo:rustc-cfg=must_use_return");
     }
+
+    // MaybeUninit<T> stabilized in Rust 1.36:
+    // https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
+    if minor >= 36 {
+        println!("cargo:rustc-cfg=maybe_uninit");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -35,13 +35,15 @@ impl Buffer {
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn new() -> Self {
+        // assume_init is safe here, since this is an array of MaybeUninit, which does not need
+        // to be initialized.
+        #[cfg(maybe_uninit)]
+        let bytes = unsafe { MaybeUninit::uninit().assume_init() };
+        #[cfg(not(maybe_uninit))]
+        let bytes = unsafe { mem::uninitialized() };
+
         Buffer {
-            // assume_init is safe here, since this is an array of MaybeUninit, which does not need
-            // to be initialized.
-            #[cfg(maybe_uninit)]
-            bytes: unsafe { MaybeUninit::uninit().assume_init() },
-            #[cfg(not(maybe_uninit))]
-            bytes: unsafe { mem::uninitialized() },
+            bytes: bytes,
         }
     }
 

--- a/src/d2s.rs
+++ b/src/d2s.rs
@@ -18,7 +18,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.
 
-use core::mem;
+use core::{mem::MaybeUninit, ptr};
 
 use common::*;
 #[cfg(not(feature = "small"))]
@@ -48,12 +48,14 @@ fn mul_shift_all(
     m: u64,
     mul: &(u64, u64),
     j: u32,
-    vp: &mut u64,
-    vm: &mut u64,
+    vp: *mut u64,
+    vm: *mut u64,
     mm_shift: u32,
 ) -> u64 {
-    *vp = mul_shift(4 * m + 2, mul, j);
-    *vm = mul_shift(4 * m - 1 - mm_shift as u64, mul, j);
+    unsafe {
+        ptr::write(vp, mul_shift(4 * m + 2, mul, j));
+        ptr::write(vm, mul_shift(4 * m - 1 - mm_shift as u64, mul, j));
+    }
     mul_shift(4 * m, mul, j)
 }
 
@@ -177,8 +179,10 @@ pub fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
 
     // Step 3: Convert to a decimal power base using 128-bit arithmetic.
     let mut vr: u64;
-    let mut vp: u64 = unsafe { mem::uninitialized() };
-    let mut vm: u64 = unsafe { mem::uninitialized() };
+    let mut vp: u64;
+    let mut vm: u64;
+    let mut vp_uninit: MaybeUninit<u64> = MaybeUninit::uninit();
+    let mut vm_uninit: MaybeUninit<u64> = MaybeUninit::uninit();
     let e10: i32;
     let mut vm_is_trailing_zeros = false;
     let mut vr_is_trailing_zeros = false;
@@ -201,10 +205,12 @@ pub fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
                 DOUBLE_POW5_INV_SPLIT.get_unchecked(q as usize)
             },
             i as u32,
-            &mut vp,
-            &mut vm,
+            vp_uninit.as_mut_ptr(),
+            vm_uninit.as_mut_ptr(),
             mm_shift,
         );
+        vp = unsafe { vp_uninit.assume_init() };
+        vm = unsafe { vm_uninit.assume_init() };
         if q <= 21 {
             // This should use q <= 22, but I think 21 is also safe. Smaller values
             // may still be safe, but it's more difficult to reason about them.
@@ -241,10 +247,12 @@ pub fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
                 DOUBLE_POW5_SPLIT.get_unchecked(i as usize)
             },
             j as u32,
-            &mut vp,
-            &mut vm,
+            vp_uninit.as_mut_ptr(),
+            vm_uninit.as_mut_ptr(),
             mm_shift,
         );
+        vp = unsafe { vp_uninit.assume_init() };
+        vm = unsafe { vm_uninit.assume_init() };
         if q <= 1 {
             // {vr,vp,vm} is trailing zeros if {mv,mp,mm} has at least q trailing 0 bits.
             // mv = 4 * m2, so it always has at least two trailing 0 bits.

--- a/src/d2s.rs
+++ b/src/d2s.rs
@@ -221,11 +221,11 @@ pub fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
             #[cfg(maybe_uninit)]
             { vp_uninit.as_mut_ptr() },
             #[cfg(not(maybe_uninit))]
-            { &mut vp as *mut u64 },
+            { &mut vp },
             #[cfg(maybe_uninit)]
             { vm_uninit.as_mut_ptr() },
             #[cfg(not(maybe_uninit))]
-            { &mut vm as *mut u64 },
+            { &mut vm },
             mm_shift,
         );
         #[cfg(maybe_uninit)]
@@ -272,11 +272,11 @@ pub fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
             #[cfg(maybe_uninit)]
             { vp_uninit.as_mut_ptr() },
             #[cfg(not(maybe_uninit))]
-            { &mut vp as *mut u64 },
+            { &mut vp },
             #[cfg(maybe_uninit)]
             { vm_uninit.as_mut_ptr() },
             #[cfg(not(maybe_uninit))]
-            { &mut vm as *mut u64 },
+            { &mut vm },
             mm_shift,
         );
         #[cfg(maybe_uninit)]

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -38,12 +38,14 @@ use no_panic::no_panic;
 /// ## Example
 ///
 /// ```edition2018
+/// use std::mem::MaybeUninit;
+///
 /// let f = 1.234f64;
 ///
 /// unsafe {
-///     let mut buffer: [u8; 24] = std::mem::uninitialized();
-///     let len = ryu::raw::format64(f, buffer.as_mut_ptr());
-///     let slice = std::slice::from_raw_parts(buffer.as_ptr(), len);
+///     let mut buffer: [MaybeUninit<u8>; 24] = MaybeUninit::uninit().assume_init();
+///     let len = ryu::raw::format64(f, buffer.as_mut_ptr() as *mut u8);
+///     let slice = std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
 ///     let print = std::str::from_utf8_unchecked(slice);
 ///     assert_eq!(print, "1.234");
 /// }
@@ -143,12 +145,14 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
 /// ## Example
 ///
 /// ```edition2018
+/// use std::mem::MaybeUninit;
+///
 /// let f = 1.234f32;
 ///
 /// unsafe {
-///     let mut buffer: [u8; 16] = std::mem::uninitialized();
-///     let len = ryu::raw::format32(f, buffer.as_mut_ptr());
-///     let slice = std::slice::from_raw_parts(buffer.as_ptr(), len);
+///     let mut buffer: [MaybeUninit<u8>; 16] = MaybeUninit::uninit().assume_init();
+///     let len = ryu::raw::format32(f, buffer.as_mut_ptr() as *mut u8);
+///     let slice = std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
 ///     let print = std::str::from_utf8_unchecked(slice);
 ///     assert_eq!(print, "1.234");
 /// }


### PR DESCRIPTION
Hello!

This PR adds use of `MaybeUninit` everywhere that `mem::uninitialized` was previously used.

The first commit does it in a breaking way, and the second commit only does it on Rust 1.36+, where `MaybeUninit` is stable, falling back on `mem::uninitialized`. I'll squash them, but I find it more readable to be able to see them separately for review purposes.

I'm not sure if I've done it 100% correctly, so I'd appreciate a review. It did require a large helping of `#[cfg]`, but I'm not sure how else to handle it.

Tests all pass and benchmarks appear unaffected.

I have a few concerns:

- I'm not handling the memory from `MaybeUninit` specially, meaning I'm not dropping it. I'm fairly certain that this is fine because it uses primitive types and doesn't allocate on the heap.
- Is one byte always written after `f.write_to_ryu_buffer`? If so, no problem, but if not, this accesses uninitialised memory.

Thanks!

(Edit: Sorry for all the pushes. 1.15.0 won't update the registry on my laptop at home for some reason.)