### PR TITLE
add decimal module for #27

### DIFF
--- a/src/d2s.rs
+++ b/src/d2s.rs
@@ -148,7 +148,7 @@ pub fn decimal_length17(v: u64) -> u32 {
     }
 }
 
-// A floating decimal representing m * 10^e.
+/// A floating decimal representing m * 10^e.
 pub struct FloatingDecimal64 {
     pub mantissa: u64,
     // Decimal exponent's range is -324 to 308

--- a/src/f2s.rs
+++ b/src/f2s.rs
@@ -173,7 +173,7 @@ fn mul_pow5_div_pow2(m: u32, i: u32, j: i32) -> u32 {
     unsafe { mul_shift(m, *FLOAT_POW5_SPLIT.get_unchecked(i as usize), j) }
 }
 
-// A floating decimal representing m * 10^e.
+/// A floating decimal representing m * 10^e.
 pub struct FloatingDecimal32 {
     pub mantissa: u32,
     // Decimal exponent's range is -45 to 38

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,3 +109,37 @@ pub use buffer::{Buffer, Float};
 pub mod raw {
     pub use pretty::{format32, format64};
 }
+
+/// Functions for converting to and from floating decimals
+pub mod decimal {
+    #[cfg(feature = "no-panic")]
+    use no_panic::no_panic;
+    use d2s;
+    pub use d2s::FloatingDecimal64;
+    use core::mem;
+
+    /// Convert a floating point number to a floating decimal
+    #[cfg_attr(feature = "no-panic", inline)]
+    #[cfg_attr(feature = "no-panic", no_panic)]
+    pub fn d2d(val: f64) -> FloatingDecimal64 {
+        let bits: u64 = unsafe { mem::transmute(val) };
+        let ieee_mantissa = bits & ((1u64 << d2s::DOUBLE_MANTISSA_BITS) - 1);
+        let ieee_exponent =
+            (bits >> d2s::DOUBLE_MANTISSA_BITS) as u32 & ((1u32 << d2s::DOUBLE_EXPONENT_BITS) - 1);
+        d2s::d2d(ieee_mantissa, ieee_exponent)
+    }
+
+    use f2s;
+    pub use f2s::FloatingDecimal32;
+
+    /// Convert a floating point number to a floating decimal
+    #[cfg_attr(feature = "no-panic", inline)]
+    #[cfg_attr(feature = "no-panic", no_panic)]
+    pub fn f2d(val: f32) -> FloatingDecimal32 {
+        let bits: u32 = unsafe { mem::transmute(val) };
+        let ieee_mantissa = bits & ((1u32 << f2s::FLOAT_MANTISSA_BITS) - 1);
+        let ieee_exponent =
+            (bits >> f2s::FLOAT_MANTISSA_BITS) as u32 & ((1u32 << f2s::FLOAT_EXPONENT_BITS) - 1);
+        f2s::f2d(ieee_mantissa, ieee_exponent)
+    }
+}


### PR DESCRIPTION
This is adds a decimal module for #27 which exposes very small wrappers around d2d and f2d from the previously private modules d2s and f2s.
