### PR TITLE
Skip init on clone

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -21,7 +21,6 @@ const NEG_INFINITY: &'static str = "-inf";
 /// let printed = buffer.format_finite(1.234);
 /// assert_eq!(printed, "1.234");
 /// ```
-#[derive(Copy, Clone)]
 pub struct Buffer {
     #[cfg(maybe_uninit)]
     bytes: [MaybeUninit<u8>; 24],
@@ -90,6 +89,15 @@ impl Buffer {
             let slice = slice::from_raw_parts(self.bytes.as_ptr() as *const u8, n);
             str::from_utf8_unchecked(slice)
         }
+    }
+}
+
+impl Copy for Buffer {}
+
+impl Clone for Buffer {
+    #[inline]
+    fn clone(&self) -> Self {
+        Buffer::new()
     }
 }
 


### PR DESCRIPTION
The cloned buffer's content is not observable until written into, so there is no need to keep it identical to the old buffer's content.