### PR TITLE
Remove unneded setup instruction for miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
-      - run: cargo miri setup
       - run: cargo miri test


### PR DESCRIPTION
According to https://www.ralfj.de/blog/2020/09/28/miri.html `cargo miri setup` is no longer needed!