### PR TITLE
Update upstream benchmark instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can run upstream's benchmarks with:
 ```console
 $ git clone https://github.com/ulfjack/ryu c-ryu
 $ cd c-ryu
-$ bazel run -c opt //ryu/benchmark
+$ bazel run -c opt //ryu/benchmark:ryu_benchmark --
 ```
 
 And the same benchmark against our implementation with:


### PR DESCRIPTION
Okay, this is the last one...

I tried running the upstream bench and couldn't because it seems the `bavel BUILD` file has been updated (I didn't look deep at how bavel works)... I've then updated bench instructions here.

The only strange thing is that in both machines I've tested (linux and macOS, both intel) the upstream benchmark runs "a lot" slower than yours, but the [bench itself](https://github.com/ulfjack/ryu/blob/master/ryu/benchmark/benchmark.cc) doesn't seem to have been touched in the last two years.

Thanks a lot for your time 😄 

Upstream ryu:
```
$ bazel run -c opt //ryu/benchmark:ryu_benchmark --
INFO: Analyzed target //ryu/benchmark:ryu_benchmark (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //ryu/benchmark:ryu_benchmark up-to-date:
  bazel-bin/ryu/benchmark/ryu_benchmark
INFO: Elapsed time: 0.099s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
    Average & Stddev Ryu  Average & Stddev Grisu3
32:   37.836    1.203      127.561    1.474
64:   45.231    0.719      141.094    1.422
```

This repository (rust ryu):
```
$  cargo run --example upstream_benchmark --release
    Finished release [optimized] target(s) in 0.09s
     Running `target/release/examples/upstream_benchmark`
             Average   Stddev
pretty32:      21.008    1.530
pretty64:      28.560    1.955
```