### PR TITLE
Fix stacked borrows violation(s) found with -Zmiri-track-raw-pointers

### DIFF
--- a/src/pretty/exponent.rs
+++ b/src/pretty/exponent.rs
@@ -14,11 +14,11 @@ pub unsafe fn write_exponent3(mut k: isize, mut result: *mut u8) -> usize {
     if k >= 100 {
         *result = b'0' + (k / 100) as u8;
         k %= 100;
-        let d = DIGIT_TABLE.get_unchecked(k as usize * 2);
+        let d = DIGIT_TABLE.as_ptr().offset(k * 2);
         ptr::copy_nonoverlapping(d, result.offset(1), 2);
         sign as usize + 3
     } else if k >= 10 {
-        let d = DIGIT_TABLE.get_unchecked(k as usize * 2);
+        let d = DIGIT_TABLE.as_ptr().offset(k * 2);
         ptr::copy_nonoverlapping(d, result, 2);
         sign as usize + 2
     } else {
@@ -38,7 +38,7 @@ pub unsafe fn write_exponent2(mut k: isize, mut result: *mut u8) -> usize {
 
     debug_assert!(k < 100);
     if k >= 10 {
-        let d = DIGIT_TABLE.get_unchecked(k as usize * 2);
+        let d = DIGIT_TABLE.as_ptr().offset(k * 2);
         ptr::copy_nonoverlapping(d, result, 2);
         sign as usize + 2
     } else {

--- a/src/pretty/mantissa.rs
+++ b/src/pretty/mantissa.rs
@@ -15,10 +15,26 @@ pub unsafe fn write_mantissa_long(mut output: u64, mut result: *mut u8) {
         let c1 = (c / 100) << 1;
         let d0 = (d % 100) << 1;
         let d1 = (d / 100) << 1;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c0 as usize), result.offset(-2), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c1 as usize), result.offset(-4), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(d0 as usize), result.offset(-6), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(d1 as usize), result.offset(-8), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c0 as isize),
+            result.offset(-2),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c1 as isize),
+            result.offset(-4),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(d0 as isize),
+            result.offset(-6),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(d1 as isize),
+            result.offset(-8),
+            2,
+        );
         result = result.offset(-8);
     }
     write_mantissa(output as u32, result);
@@ -31,19 +47,35 @@ pub unsafe fn write_mantissa(mut output: u32, mut result: *mut u8) {
         output /= 10_000;
         let c0 = (c % 100) << 1;
         let c1 = (c / 100) << 1;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c0 as usize), result.offset(-2), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c1 as usize), result.offset(-4), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c0 as isize),
+            result.offset(-2),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c1 as isize),
+            result.offset(-4),
+            2,
+        );
         result = result.offset(-4);
     }
     if output >= 100 {
         let c = ((output % 100) << 1) as u32;
         output /= 100;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c as usize), result.offset(-2), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c as isize),
+            result.offset(-2),
+            2,
+        );
         result = result.offset(-2);
     }
     if output >= 10 {
         let c = (output << 1) as u32;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c as usize), result.offset(-2), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c as isize),
+            result.offset(-2),
+            2,
+        );
     } else {
         *result.offset(-1) = b'0' + output as u8;
     }


### PR DESCRIPTION
Originally found by @5225225

Running `MIRIFLAGS="-Zmiri-track-raw-pointers" cargo miri test` (this flag will soon be renamed to `-Zmiri-tag-raw-pointers`) turns up this:
```
test test_looks_like_pow5 ... error: Undefined Behavior: no item granting read access to tag <234329> at alloc84812+0x47 found in borrow stack.
    --> /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/intrinsics.rs:2079:14
     |
2079 |     unsafe { copy_nonoverlapping(src, dst, count) }
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item granting read access to tag <234329> at alloc84812+0x47 found in borrow stack.
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

     = note: inside `std::intrinsics::copy_nonoverlapping::<u8>` at /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/intrinsics.rs:2079:14
     = note: inside `ryu::pretty::mantissa::write_mantissa_long` at /home/ben/ryu/src/pretty/mantissa.rs:18:9
     = note: inside `ryu::raw::format64` at /home/ben/ryu/src/pretty/mod.rs:109:9
     = note: inside `<f64 as ryu::buffer::Sealed>::write_to_ryu_buffer` at /home/ben/ryu/src/buffer/mod.rs:180:9
     = note: inside `ryu::Buffer::format_finite::<f64>` at /home/ben/ryu/src/buffer/mod.rs:86:21
     = note: inside `ryu::Buffer::format::<f64>` at /home/ben/ryu/src/buffer/mod.rs:63:13
note: inside `pretty` at tests/d2s_test.rs:37:5
    --> tests/d2s_test.rs:37:5
     |
37   |     ryu::Buffer::new().format(f).to_owned()
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
I'm pretty sure this is because the `get_unchecked` call returns a pointer which only has provenance over the element at that index, but these `copy_nonoverlapping` calls are used to read the element after that index as well.