### PR TITLE
Track raw pointers in miri CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           components: miri
       - run: cargo miri test
+        env:
+          MIRIFLAGS: "-Zmiri-track-raw-pointers"
 
   clippy:
     name: Clippy


### PR DESCRIPTION
I'm not sure if this is even correct, but from reading the docs (https://docs.github.com/en/actions/learn-github-actions/environment-variables), this *should* export a flag that's visible to miri.