### PR TITLE
Enable u128 codepath for Emscripten targets on rust 1.40+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,9 +14,10 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let emscripten = target == "asmjs-unknown-emscripten" || target == "wasm32-unknown-emscripten";
 
-    // 128-bit integers disabled on Emscripten targets as Emscripten doesn't
-    // currently support integers larger than 64 bits.
-    if !emscripten {
+    // 128-bit integers Disabled on Emscripten targets before Rust 1.40 since
+    // Emscripten did not support 128-bit integers until Rust 1.40
+    // (https://github.com/rust-lang/rust/pull/65251)
+    if !emscripten || minor >= 40 {
         println!("cargo:rustc-cfg=integer128");
     }
 


### PR DESCRIPTION
rust-lang/rust#65251 fixed the issue where Rust was unable to support 128-bit integers on emscripten targets. The fix has been in rustc since 1.40.0.