### PR TITLE
Mark exhaustive test #[ignore] in non-cfg(exhaustive)

### DIFF
--- a/tests/exhaustive.rs
+++ b/tests/exhaustive.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(check_cfg), allow(unexpected_cfgs))]
-#![cfg(exhaustive)]
 #![allow(clippy::cast_possible_truncation)]
 
 use std::str;
@@ -8,6 +7,7 @@ use std::sync::Arc;
 use std::thread;
 
 #[test]
+#[cfg_attr(not(exhaustive), ignore = "requires cfg(exhaustive)")]
 fn test_exhaustive() {
     const BATCH_SIZE: u32 = 1_000_000;
     let counter = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
This allows `cargo check --tests` to typecheck this code, and IDEs to provide useful behavior, unlike when the whole integration test file is configured out.