### PR TITLE
add: public visibility to f2s module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ mod d2s_intrinsics;
 #[cfg(feature = "small")]
 mod d2s_small_table;
 mod digit_table;
-mod f2s;
+pub mod f2s;
 mod f2s_intrinsics;
 mod pretty;
 #[cfg(test)]


### PR DESCRIPTION
I have some use cases where I dont want to convert the float to a decimal based string but do need to convert it to a decimal based representation. I want to use the f2d method external to this crate.